### PR TITLE
use rmarkdown; remove static toc; render headers correctly

### DIFF
--- a/vignettes/SGSeqBioC2015.Rmd
+++ b/vignettes/SGSeqBioC2015.Rmd
@@ -1,5 +1,15 @@
 ---
-output:
+title: "SGSeq"
+author: "Leonard D GoldStein"
+date: "`r BiocStyle::doc_date()`"
+package: "`r BiocStyle::pkg_ver('SGSeqBioC2015')`"
+abstract: >
+  SGSeq
+vignette: >
+  %\VignetteIndexEntry{SGSeq}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+output: 
   BiocStyle::html_document:
     toc: true
 ---

--- a/vignettes/SGSeqBioC2015.Rmd
+++ b/vignettes/SGSeqBioC2015.Rmd
@@ -20,14 +20,8 @@ opts_chunk$set(error = FALSE)
 ```
 
 ```{r style, echo = FALSE, results = 'asis'}
-BiocStyle::markdown()
+##BiocStyle::markdown()
 ```
-
-<!--
-%\VignetteIndexEntry{SGSeq}
-%\VignettePackage{SGSeqBioC2015}
-%\VignetteEngine{knitr::rmarkdown}
--->
 
 # Splice event detection and quantification from RNA-seq data with *SGSeq*
 
@@ -39,27 +33,10 @@ Leonard D Goldstein [1, 2]
 
 Genentech, Inc., South San Francisco, CA, USA.
 
-## Contents
-
-* [Abstract] (#abstract)
-* [Preliminaries] (#preliminaries)
-* [Transcript features and the *TxFeatures* class] (#txfeatures)
-* [Splice graph features and the *SGFeatures* class] (#sgfeatures)
-* [Analysis based on annotated transcripts] (#annotated)
-* [Analysis based on *de novo* prediction] (#predicted)
-* [Analysis of predicted splice variants] (#variants)
-* [Visualization] (#visualization)
-* [Advanced use] (#advanced)
-* [Exercises] (#exercises)
-* [References] (#references)
-* [Session information] (#session)
-
-<a id="abstract"></a>
 ## Abstract
 
 The *SGSeq* package provides a framework for analyzing annotated and novel splice events from RNA-seq data. *SGSeq* predicts exons and splice junctions from reads aligned against a reference genome and assembles them into a genome-wide splice graph. Splice events are identified from the graph and quantified using reads spanning event boundaries. This workshop provides an introduction to *SGSeq* functionality, including splice event detection, quantification, annotation and visualization. The first part of the workshop illustrates a complete *SGSeq* workflow for analyzing a gene of interest starting from BAM files. The second part of the workshop covers exercises based on a genomewide data set previously processed with *SGSeq*. 
 
-<a id="preliminaries"></a>
 ## Preliminaries
 
 ```{r, message = FALSE}
@@ -81,7 +58,6 @@ path <- system.file("extdata", package = "SGSeq")
 si$file_bam <- file.path(path, "bams", si$file_bam)
 ``` 
 
-<a id="txfeatures"></a>
 ## Transcript features and the *TxFeatures* class
 
 We use the UCSC knownGene table as reference annotation, which is available as a *Bioconductor* annotation package `r Biocannopkg("TxDb.Hsapiens.UCSC.hg19.knownGene")`. We retain transcripts on chromosome 16, where the *FBXO31* gene is located, and change chromosome names in the annotation to match chromosome names in the BAM files.
@@ -115,7 +91,6 @@ Metadata columns can be accessed using accessor functions named after the column
 
 If transcript annotation is not available as a *TxDb* object, function *convertToTxFeatures* can construct *TxFeatures* from a *GRangesList* of exons grouped by transcript (see [Exercises] (#exercises) below).
 
-<a id="sgfeatures"></a>
 ## Splice graph features and the *SGFeatures* class
 
 Exons stored as *TxFeatures* can be overlapping (e.g. due to alternative splice sites) resulting in ambiguities (e.g. when when trying to assign reads to individual exons). We therefore partition exonic regions into disjoint exon bins. Splice junctions and disjoint exon bins uniquely determine a genome-wide splice graph ([Heber et al. 2002] (#heber)). To store splice graph features, *SGSeq* implements the *SGFeatures* class. 
@@ -140,7 +115,6 @@ Column *featureID* provides a unique identifier for each feature, while columnn 
 
 Both *TxFeatures* and *SGFeatures* objects can be exported to BED files using function *exportFeatures*.
 
-<a id="annotated"></a>
 ## Analysis based on annotated transcripts
 
 We can now start analyzing the RNA-seq data at the *FBXO31* gene locus. We first perform an analysis based on annotated transcripts. The following example converts the transcript features into splice graph features and obtains counts of compatible RNA-seq reads for each feature and each sample. 
@@ -161,7 +135,6 @@ df
 
 Note that the splice graph derived from annotated transcripts includes three alternative transcript start sites (TSSs). However, the heatmap indicates that the first TSS is not used in the samples in our data set.
 
-<a id="predicted"></a>
 ## Analysis based on *de novo* prediction
 
 Instead of relying on existing annotation, *SGSeq* can predict features from BAM files directly. The following code block predicts splice graph features with read evidence in our data set.
@@ -185,7 +158,6 @@ df
 
 Note that most exons and splice junctions predicted from the RNA-seq data are consistent with transcripts in the UCSC knownGene table (shown in gray). However, in contrast to the previous figure, the predicted gene model does not include parts of the splice graph that are not expressed in our data set. Also, an unannotated exon (E3, shown in red) was discovered from the RNA-seq data, which is expressed in three of the four normal colorectal samples (N2, N3, N4). 
 
-<a id="variants"></a>
 ## Analysis of predicted splice variants
 
 Instead of considering the complete splice graph of a gene, we can focus our analysis on individual splice events. In the *SGSeq* framework, the splice graph is a directed acyclic graph with nodes corresponding to transcript starts, ends and splice sites, and edges corresponding to disjoint exon bins and splice junctions, directed from 5$^\prime$ to the 3$^\prime$ end. A splice event is defined by a start node and an end node connected by two or more paths and no intervening nodes with all paths intersecting. *SGSeq* identifies splice events recursively from the graph, and estimates relative usage of splice variants based on compatible reads spanning the event boundaries. The following example identifies splice events from the splice graph and obtains representative counts for each splice variant.
@@ -219,7 +191,6 @@ plotVariants(sgvc_pred, eventID = 1, color_novel = "red")
 
 *plotVariants* generates a two-panel figure similar to *plotFeatures*. The splice graph in the top panel illustrates the selected splice event. In this example, the splice event consists of two splice variants that correspond to a skip or inclusion of the unannotated exon. The heatmap illustrates estimates of relative usage for each splice variant. We observe that samples N2, N3 and N4 show evidence for both transcripts that include the exon as well as transcripts that skip the exon. The remaining samples show little evidence for exon inclusion.
 
-<a id="visualization"></a>
 ## Visualization
 
 Functions *plotFeatures* and *plotVariants* support many options for customizing figures. Note that the splice graph in the top figure panel is plotted by function *plotSpliceGraph*, which can be called directly. 
@@ -258,7 +229,6 @@ for (j in 1:4) {
 }
 ```
 
-<a id="advanced"></a>
 ## Advanced use
 
 Functions *analyzeFeatures* and *analyzeVariants* wrap multiple analysis steps for convenience. Alternatively, the functions performing individual steps can be called directly. For example, the previous analysis using *de novo* prediction can be performed as follows.
@@ -274,7 +244,6 @@ sgvc <- getSGVariantCounts(sgv, sgfc)
 
 *predictTxFeatures* and *getSGFeatureCounts* can be run on individual samples (e.g. for distribution across a high-performance computing cluster). *predictTxFeatures* predicts features for each sample, merges features across samples and finally performs filtering and processing of predicted terminal exons. When using *predictTxFeatures* for individual samples, with predictions intended to be merged at a later point in time, run *predictTxFeatures* with argument *min_overhang = NULL* to suppress processing of terminal exons. Then predictions can subsequently be merged and processed with functions *mergeTxFeatures* and *processTerminalExons*, respectively.
 
-<a id="exercises"></a>
 ## Exercises
 
 **Exercise 1** Construct a *TxFeatures* object for a transcript with three exons. What happens if you add a second transcript with exons that are shared or overlapping with exons in the first transcript? What happens if you convert the *TxFeatures* object to an *SGFeatures* object? 
@@ -343,22 +312,16 @@ geneIDs <- geneID(exons)[order(exons_FPKM_max, decreasing = TRUE)]
 plotFeatures(sgfc_IBM, geneID = geneIDs[1], color_novel = "red")
 ```
 
-<a id="references"></a>
 ## References
 
-<a id="seshagiri"></a>
 Seshagiri S, Stawiski EW, Durinck S, Modrusan Z, Storm EE, Conboy CB, Chaudhuri S, Guan Y, Janakiraman V, Jaiswal BS, Guillory J, Ha C, Dijkgraaf GJP, Stinson J, Gnad F, Huntley MA, Degenhardt JD, Haverty PM, Bourgon R, Wang W, Koeppen H, Gentleman R, Starr TK, Zhang Z, Largaespada DA, Wu TD, de Sauvage FJ. "Recurrent R-spondin fusions in colon cancer." *Nature* 488, 660--664, 2012.
 
-<a id="lawrence"></a>
 Lawrence M, Huber W, Pages H, Aboyoun P, Carlson M, Gentleman R, Morgan MT, Carey VJ. "Software for Computing and Annotating Genomic Ranges." *PLOS Computational Biology* 9, e1003118, 2013.
 
-<a id="heber"></a>
 Heber S, Alekseyev M, Sze S, Tang H, Pevzner PA. "Splicing graphs and EST assembly problem." *Bioinformatics* 18 Suppl 1, S181--188, 2002.
 
-<a id="farrell"></a>
 Farrell CM, O'Leary NA, Harte RA, Loveland JE, Wilming LG, Wallin C, Diekhans M, Barrell D, Searle SM, Aken B, Hiatt SM, Frankish A, Suner MM, Rajput B, Steward CA, Brown GR, Bennett R, Murphy M, Wu W, Kay MP, Hart J, Rajan J, Weber J, Snow C, Riddick LD, Hunt T, Webb D, Thomas M, Tamez P, Rangwala SH, McGarvey KM, Pujar S, Shkeda A, Mudge JM, Gonzalez JM, Gilbert JG, Trevanion SJ, Baertsch R, Harrow JL, Hubbard T, Ostell JM, Haussler D, Pruitt KD. "Current status and new features of the Consensus Coding Sequence database". *Nucleic Acids Research* 42(Database issue):D865-72, 2014.
 
-<a id="session"></a>
 ## Session information
 
 ```{r}


### PR DESCRIPTION
Hi Leonard,

I tweaked your package a bit so that it would really use rmarkdown and BiocStyle. As a result the static toc you had is no longer needed and has been removed. I also removed the <a id=...> tags since they were no longer needed and also stopped headers from being rendered correctly, since they are supposed to have a blank line above them.

Please merge this pull request so that the formatting is correct going forward. 

Thanks,
Dan
